### PR TITLE
Remove duplicate definition of mixin t4.

### DIFF
--- a/packages/kth-style/public/sass/variables/_fonts.scss
+++ b/packages/kth-style/public/sass/variables/_fonts.scss
@@ -124,15 +124,6 @@ $h4-fontSize: 1.25rem !default; // 20px
   line-height: 1.375;
 }
 
-// Block heading
-@mixin t4 ($color : true) {
-  font-family: $sansSerif;
-  font-size: $h3-fontSize;
-  font-weight: 600;
-  @if ($color) { color: $black;}
-  line-height: 1.375;
-}
-
 // Block heading full width
 @mixin t24 ($color : true)  {
   font-family: $sansSerif;


### PR DESCRIPTION
The same definition of `@mixin t4` was repeated twice, remove one of them.