### PR TITLE
Less disruptive default styling for list items.

### DIFF
--- a/packages/kth-style/public/sass/bootstrap/_variables.scss
+++ b/packages/kth-style/public/sass/bootstrap/_variables.scss
@@ -24,7 +24,7 @@ $danger: $red;
 $body-color: $black;
 
 $font-family-sans-serif: $sansSerif;
-$font-family-base: $sansSerif;
+$font-family-base: $serif;
 
 // Headings
 $h1-font-size: $h1-fontSize;

--- a/packages/kth-style/public/sass/custom/commonStyle.scss
+++ b/packages/kth-style/public/sass/custom/commonStyle.scss
@@ -19,19 +19,10 @@ body {
   }
 }
 
-ul {
+ul, ol {
   li {
-    font-family: $serif;
-    font-weight: normal;
-    line-height: 1.6875;
-  }
-}
-
-ol {
-  li {
-    font-family: $serif;
-    font-weight: normal;
-    line-height: 1.6875;
+    font: inherit;
+    line-height: inherit;
   }
 }
 

--- a/packages/kth-style/public/sass/custom/commonStyle.scss
+++ b/packages/kth-style/public/sass/custom/commonStyle.scss
@@ -19,13 +19,6 @@ body {
   }
 }
 
-ul, ol {
-  li {
-    font: inherit;
-    line-height: inherit;
-  }
-}
-
 .lead {
   font-family: $sansSerif;
   font-weight: normal;
@@ -40,8 +33,6 @@ ul, ol {
 
 .paragraphs {
   p {
-    font-family: $serif;
-    font-weight: normal;
     line-height: 1.6875;
     margin: 0 0 27px 0;
     max-width: 730px;


### PR DESCRIPTION
Brutally setting serif font for any list item anywhere just causes massive need for overrides everywhere.  It was probably intended as a cross-browser reset, so use inherit as a less disruptive reset.