### PR TITLE
Introduce $widePageWidth

### DIFF
--- a/packages/kth-style/public/sass/custom/commonStyle.scss
+++ b/packages/kth-style/public/sass/custom/commonStyle.scss
@@ -10,7 +10,7 @@ body {
 
   .container {
     &.main {
-      max-width: 1228px;
+      max-width: $widePageWidth;
       margin: 0 auto; 
     }
   }

--- a/packages/kth-style/public/sass/custom/slots/footer.scss
+++ b/packages/kth-style/public/sass/custom/slots/footer.scss
@@ -143,7 +143,7 @@ footer {
 
   @media (min-width: 1258px) {
     &.container {
-        max-width: 1228px;
+        max-width: $widePageWidth;
         margin: auto;
     }
   }

--- a/packages/kth-style/public/sass/custom/slots/header.scss
+++ b/packages/kth-style/public/sass/custom/slots/header.scss
@@ -10,7 +10,7 @@ body {
     .container-fluid {
       .container {
         margin: 0 auto;
-        max-width: 1228px;
+        max-width: $widePageWidth;
         padding: $gutter 0 20px;
 
         @media (min-width: 992px) {

--- a/packages/kth-style/public/sass/variables/_sizes.scss
+++ b/packages/kth-style/public/sass/variables/_sizes.scss
@@ -6,3 +6,5 @@ $quarterSpacing: ($spacing / 4);
 $pageInset: 38px;
 
 $bodyLineHeight: 1.3;
+
+$widePageWidth: 1228px;


### PR DESCRIPTION
Use a variable rather than repeating the hardcoded number of pixels for both the header, main body and footer.

I also considered creating a mixin including margis and breakpoints, but since things are done differently for the header and the other blocks, that may have to wait.  But I think this piece is harmless and should be merged before the initial public release.