### PR TITLE
Use explicit https for the fonts.googleapis.com url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "//": "JSHint configuration - http://jshint.com/docs/options/",
   "name": "kth-style",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "KTH CSS. A custom build of Bootstrap 4. The purpose of this project is to provide the essential design and style for applications within KTH and make the development process of these applications faster.",
   "private": false,
   "license": "MIT",

--- a/public/sass/variables/_fonts.scss
+++ b/public/sass/variables/_fonts.scss
@@ -6,7 +6,7 @@
 @import './sizes';
 
 // Import of font Open Sans
-@import url('//fonts.googleapis.com/css?family=Open+Sans:200,300,400,500,600');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:200,300,400,500,600');
 $open-sans: 'Open Sans';
 
 $serif: 'Georgia', 'garamond pro', garamond, 'times new roman', times, serif;


### PR DESCRIPTION
Is there a reason for using an url without a protocol when `@import` -ing Open Sans from fonts.googleapis?  It confuses parcel-bundler, so it would be nice if we can put an explicit `https:` there.

This PR adds the protocol.  But I don't know the routines for putting out an actual release?