### PR TITLE
Create padding utility classes for print

### DIFF
--- a/public/sass/bootstrap/_utilities.scss
+++ b/public/sass/bootstrap/_utilities.scss
@@ -1,0 +1,12 @@
+$utilities: map-merge(
+  $utilities,
+  (
+    'padding':
+      map-merge(
+        map-get($utilities, 'padding'),
+        (
+          print: true,
+        )
+      ),
+  )
+);

--- a/public/sass/kth-bootstrap.scss
+++ b/public/sass/kth-bootstrap.scss
@@ -54,6 +54,7 @@
 @import 'node_modules/bootstrap/scss/helpers';
 
 // 7. Optionally include utilities API last to generate classes based on the Sass map in `_utilities.scss`
+@import 'bootstrap/utilities';
 @import 'node_modules/bootstrap/scss/utilities/api';
 
 // ----------------------------------


### PR DESCRIPTION
# tl;dr

We would love to use the class `p-print-3` to apply padding to an element only when printing, to have a nice looking pdf or printout. Plz merge! 😍 

# Change

Bootstrap has some built-in utility classes to e.g. only display elements if the user is printing a website (i.e. within the @media print media query. Print utility classes for additional properties have to explicitly be enabled according to: https://getbootstrap.com/docs/5.3/utilities/api/#print

This change is _modifying_ the utility classes for **padding** (according to https://getbootstrap.com/docs/5.3/utilities/api/#modify-utilities), and thus additionally creating utility classes p-print-0 to p-print-5, while leaving all other classes untouched.


The created classes:

```css
.p-print-0 {
	padding: 0 !important;
}

.p-print-1 {
	padding: 0.325rem !important;
}

.p-print-2 {
	padding: 0.65rem !important;
}

.p-print-3 {
	padding: 1.3rem !important;
}

.p-print-4 {
	padding: 1.95rem !important;
}

.p-print-5 {
	padding: 3.9rem !important;
}

```

# Our use case

We want to create beautiful printouts (or save to pdfs) with nice padding.

Currently:
![pdf-bad](https://github.com/KTH/kth-style/assets/3601810/11cf23c9-20a5-44e4-a1b3-ae16dcde45ba)

How things could be:
![pdf-good](https://github.com/KTH/kth-style/assets/3601810/ae9417d0-37ef-4e0d-9e15-32a983d9689e)

