### PR TITLE
Fix: reintroduce table border-collapse

### DIFF
--- a/public/sass/bootstrap/_reboot.scss
+++ b/public/sass/bootstrap/_reboot.scss
@@ -7,12 +7,13 @@
 //
 // Normalize is licensed MIT. https://github.com/necolas/normalize.css
 
-// Body
+// Tables
 //
-// 1. Remove the margin in all browsers.
-// 2. As a best practice, apply a default `background-color`.
-// 3. Prevent adjustments of font size after orientation changes in iOS.
-// 4. Change the default tap highlight to be completely transparent in iOS.
+// Prevent double borders
+
+table {
+  border-collapse: collapse;
+}
 
 // Typography
 //


### PR DESCRIPTION
Removed unnecessary Body comment and reintroduced `border-collapse` for `table` to retain table styles from KTH Style 9 in 10.

It was removed in commit cb874d25d71afca9cf871cb5c5269d4727f88547.